### PR TITLE
Resource lifecycle / close interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ pip install kospel-cmi-lib
 
 ## Usage
 
-Create a register backend (HTTP or YAML), then pass it to `HeaterController`:
+Create a register backend (HTTP or YAML), then pass it to `HeaterController`.
+When using `HttpRegisterBackend`, call `aclose()` or use the controller as an
+async context manager to release the HTTP session when done.
+
+**Recommended: async context manager** (resources released automatically):
 
 ```python
 import asyncio
@@ -35,17 +39,29 @@ async def main() -> None:
     api_base_url = "http://192.168.1.1/api/dev/65"  # Replace with your heater URL
     async with aiohttp.ClientSession() as session:
         backend = HttpRegisterBackend(session, api_base_url)
-        controller = HeaterController(backend=backend)
-        await controller.refresh()
-        print(controller.heater_mode)  # Access registry-defined settings as attributes
-        # controller.heater_mode = "manual"  # Modify (if writable)
-        # await controller.save()  # Write pending changes to the device
+        async with HeaterController(backend=backend) as controller:
+            await controller.refresh()
+            print(controller.heater_mode)  # Access registry-defined settings
+            # controller.heater_mode = "manual"  # Modify (if writable)
+            # await controller.save()  # Write pending changes to the device
+    # Session and controller resources released here
 
 
 asyncio.run(main())
 ```
 
-For offline development or tests, use the YAML backend (no HTTP):
+**Alternative: explicit `aclose()`** (for long-lived integrations like Home Assistant):
+
+```python
+controller = HeaterController(backend=HttpRegisterBackend(session, api_base_url))
+try:
+    await controller.refresh()
+    # ... use controller ...
+finally:
+    await controller.aclose()
+```
+
+For offline development or tests, use the YAML backend (no HTTP, no close needed):
 
 ```python
 backend = YamlRegisterBackend(state_file="/path/to/state.yaml")

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,3 +20,7 @@
   - `kospel_cmi.controller.registry` (SettingDefinition)
   - `kospel_cmi.kospel.backend` (YamlRegisterBackend, write_flag_bit)
   - `kospel_cmi.controller.api` (HeaterController with mock RegisterBackend)
+  - Resource lifecycle: `HeaterController.aclose()` and `async with HeaterController(...)`
+    close HTTP session via `HttpRegisterBackend.aclose()`. YamlRegisterBackend has no
+    closeable resources. Unit tests for aclose and context manager in
+    `test_backend.py` and `test_heater_controller.py`.

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -193,7 +193,7 @@ Bit 15  14  13  12  11  10  9   8   7   6   5   4   3   2   1   0
 
 **Session Management**:
 - `aiohttp.ClientSession` passed explicitly (no global state)
-- Session lifecycle managed by caller (context manager recommended)
+- When using `HttpRegisterBackend`, call `HeaterController.aclose()` when done, or use `async with HeaterController(backend=...)` to release the session automatically
 - Supports connection pooling and keep-alive
 
 **Function Signatures**:

--- a/src/kospel_cmi/kospel/backend.py
+++ b/src/kospel_cmi/kospel/backend.py
@@ -47,6 +47,8 @@ class RegisterBackend(Protocol):
 class HttpRegisterBackend:
     """Backend that uses HTTP API to read/write registers."""
 
+    _session: Optional[aiohttp.ClientSession]
+
     def __init__(
         self,
         session: aiohttp.ClientSession,
@@ -81,6 +83,16 @@ class HttpRegisterBackend:
         return await kospel_api.write_register(
             self._session, self._api_base_url, register, hex_value
         )
+
+    async def aclose(self) -> None:
+        """Close the HTTP session and release resources.
+
+        Safe to call multiple times (idempotent). After closing, the backend
+        must not be used for further read/write operations.
+        """
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
 
 
 class YamlRegisterBackend:

--- a/tests/unit/kospel/test_backend.py
+++ b/tests/unit/kospel/test_backend.py
@@ -2,9 +2,31 @@
 
 from pathlib import Path
 
+import aiohttp
 import pytest
 
-from kospel_cmi.kospel.backend import YamlRegisterBackend, write_flag_bit
+from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend, write_flag_bit
+
+
+class TestHttpRegisterBackendAclose:
+    """Tests for HttpRegisterBackend.aclose()."""
+
+    @pytest.mark.asyncio
+    async def test_aclose_closes_session(self) -> None:
+        """aclose() closes the underlying ClientSession."""
+        async with aiohttp.ClientSession() as session:
+            backend = HttpRegisterBackend(session, "http://localhost/api/dev/65")
+            assert not session.closed
+            await backend.aclose()
+            assert session.closed
+
+    @pytest.mark.asyncio
+    async def test_aclose_idempotent(self) -> None:
+        """Calling aclose() multiple times does not raise."""
+        async with aiohttp.ClientSession() as session:
+            backend = HttpRegisterBackend(session, "http://localhost/api/dev/65")
+            await backend.aclose()
+            await backend.aclose()  # Second call should not raise
 
 
 class TestYamlRegisterBackend:

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a1"
+version = "0.1.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
# Resource lifecycle / close interface

## Problem
HeaterController with HttpRegisterBackend holds an aiohttp.ClientSession but exposes no API to close it. Consumers (e.g. Home Assistant) had to rely on internals (heater_controller._backend._session) to close the session on unload.

## Solution
Added a public lifecycle API for releasing resources:
1. HttpRegisterBackend.aclose() – closes the HTTP session, idempotent (safe to call multiple times).
2. HeaterController.aclose() – delegates to backend’s aclose() when it exists.
3. HeaterController as async context manager – async with HeaterController(...) enters and calls aclose() on exit.
aclose() on backends is optional (getattr(..., "aclose", None)), so YamlRegisterBackend is unchanged and requires no close.

## Usage
```python
# Recommended: async context managerasync
with aiohttp.ClientSession() as session:
  backend = HttpRegisterBackend(session, api_base_url)
  async with HeaterController(backend=backend) as controller:
    await controller.refresh()
    # ...

# Alternative: explicit aclose() (e.g. integration unload)await controller.aclose()
```
Changes
- `src/kospel_cmi/kospel/backend.py`: added HttpRegisterBackend.aclose().
- `src/kospel_cmi/controller/api.py`: added HeaterController.aclose(), __aenter__, __aexit__.
- `README`, `docs/technical.md`: updated docs and examples.
- New tests for aclose and the context manager.

Closes #1.