### PR TITLE
Add action to test PRs

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,40 @@
+# Run tests on pull requests when ready for review or when new commits are pushed.
+# Triggers:
+# - New PR (not draft) created
+# - Draft PR marked as ready for review
+# - New commits pushed to an open PR
+name: Test PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Skip draft PRs: only run when PR is ready for review
+    # - opened: only if not draft
+    # - synchronize: only if not draft (open PR)
+    # - ready_for_review: always run (PR is no longer draft)
+    if: |
+      (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
+      (github.event.action == 'synchronize' && github.event.pull_request.draft == false) ||
+      github.event.action == 'ready_for_review'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Add GitHub Actions workflow for PR testing

### Summary
Adds a GitHub Actions workflow that automatically runs tests on pull requests when they're ready for review or when new commits are pushed.

### Changes
- Created `.github/workflows/test-pr.yml` workflow
- Runs tests automatically on PR events:
  - ✅ New PR (non-draft) opened
  - ✅ Draft PR marked as ready for review
  - ✅ New commits pushed to an open PR

### Behavior
- **Skips draft PRs**: Tests only run when PRs are ready for review
- **Consistent setup**: Uses same configuration as release workflow (`uv`, Python 3.12, `pytest`)
- **Follows existing patterns**: Matches the structure and style of `release-pypi.yml`

### Technical Details
- **Event types**: `opened`, `synchronize`, `ready_for_review`
- **Condition logic**: Skips draft PRs on `opened` and `synchronize` events; always runs on `ready_for_review`
- **Test execution**: `uv sync --all-groups` → `uv run pytest`

### Benefits
- ✅ Provides early feedback on PRs before review
- ✅ Prevents regressions from new commits
- ✅ Reduces manual testing overhead
- ✅ Maintains code quality standards

### Testing
The workflow will be validated automatically on the next PR that meets the trigger conditions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new GitHub Actions workflow only, with no runtime or library code changes. Main risk is increased CI usage or unexpected workflow triggering/skip behavior for draft PRs.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/test-pr.yml`) that runs the test suite on pull request activity (`opened`, `synchronize`, `ready_for_review`).
> 
> The job **skips draft PRs** via a conditional, sets up Python 3.12 with `uv`, installs dependencies (`uv sync --all-groups`), and executes `pytest` (`uv run pytest`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aeb4b2d4bfb7626ad71c8a7ba1b327cde0b128c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->