### PR TITLE
Kospel CMI-810 data

### DIFF
--- a/src/kospel_cmi/controller/README.md
+++ b/src/kospel_cmi/controller/README.md
@@ -19,6 +19,17 @@ controller = HeaterController(backend=backend, registry=registry)
 
 All config files live in `configs/`. To add a new device variant, create a new YAML file (e.g. `kospel_cmi_pro.yaml`) and load it with `load_registry("kospel_cmi_pro")`.
 
+### Async Runtime Note (Home Assistant, asyncio apps)
+
+When called inside a running event loop, `load_registry()` performs blocking file
+I/O. Use `async_load_registry()` instead:
+
+```python
+from kospel_cmi.controller.registry import async_load_registry
+
+registry = await async_load_registry("kospel_cmi_standard")
+```
+
 ## YAML Schema
 
 **Simple decoder (no params):**

--- a/src/kospel_cmi/controller/registry.py
+++ b/src/kospel_cmi/controller/registry.py
@@ -4,10 +4,11 @@ Registry of the heater registers. It contains list of known registers and inform
 Settings are loaded from YAML config files via load_registry(name). Configs live in the package configs/ directory.
 """
 
+import asyncio
+from dataclasses import dataclass
 import logging
 from importlib import resources
 from pathlib import Path
-from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
 import yaml
@@ -231,3 +232,28 @@ def load_registry(
             ) from e
 
     return result
+
+
+async def async_load_registry(
+    name: str,
+    config_dir: Optional[Path] = None,
+) -> dict[str, SettingDefinition]:
+    """Load settings registry without blocking the event loop.
+
+    This helper is intended for async runtimes (for example Home Assistant setup
+    code) where synchronous file reads would block the loop. The synchronous
+    ``load_registry`` implementation is executed in a worker thread.
+
+    Args:
+        name: Config file name without extension
+            (e.g. ``"kospel_cmi_standard"``).
+        config_dir: Optional directory for config files (used in tests). If
+            ``None``, loads from package ``configs/``.
+
+    Returns:
+        Dict mapping setting names to ``SettingDefinition``.
+
+    Raises:
+        RegistryConfigError: If config is invalid, incomplete, or not found.
+    """
+    return await asyncio.to_thread(load_registry, name, config_dir)

--- a/tests/unit/controller/test_config_loader.py
+++ b/tests/unit/controller/test_config_loader.py
@@ -7,8 +7,9 @@ import pytest
 
 from kospel_cmi.controller.registry import (
     RegistryConfigError,
-    load_registry,
     SettingDefinition,
+    async_load_registry,
+    load_registry,
 )
 
 
@@ -107,6 +108,25 @@ class TestLoadRegistry:
         """Unknown config name raises RegistryConfigError."""
         with pytest.raises(RegistryConfigError, match="not found"):
             load_registry("nonexistent_config")
+
+
+class TestAsyncLoadRegistry:
+    """Tests for async_load_registry helper."""
+
+    @pytest.mark.asyncio
+    async def test_async_load_registry_returns_dict_of_setting_definitions(self) -> None:
+        """async_load_registry returns Dict[str, SettingDefinition]."""
+        registry = await async_load_registry("kospel_cmi_standard")
+        assert isinstance(registry, dict)
+        assert all(isinstance(v, SettingDefinition) for v in registry.values())
+        assert "heater_mode" in registry
+        assert "manual_temperature" in registry
+
+    @pytest.mark.asyncio
+    async def test_async_load_registry_unknown_config_raises(self) -> None:
+        """Unknown config name raises RegistryConfigError in async path."""
+        with pytest.raises(RegistryConfigError, match="not found"):
+            await async_load_registry("nonexistent_config")
 
 
 class TestRegistryConfigValidation:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `async_load_registry` to prevent Home Assistant event-loop blocking during registry loading.

The existing `load_registry` performed synchronous file I/O, which caused blocking warnings in async environments like Home Assistant. The new `async_load_registry` uses `asyncio.to_thread` to offload this synchronous operation to a separate thread, resolving the blocking issue reported in GitHub issue #20.

<div><a href="https://cursor.com/agents/bc-d43fc52c-33a6-40b8-b18b-b980de54f3bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d43fc52c-33a6-40b8-b18b-b980de54f3bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->