### PR TITLE
Add power limit settings

### DIFF
--- a/src/kospel_cmi/controller/README.md
+++ b/src/kospel_cmi/controller/README.md
@@ -36,12 +36,14 @@ await controller.set_water_comfort_temperature(38.0)
 - `cwu_mode`, `cwu_temperature_economy`, `cwu_temperature_comfort`
 - `is_water_heater_enabled`, `is_co_heating_active`, `is_cwu_heating_active`
 - `co_heating_status`, `cwu_heating_status` (computed)
-- `pressure`, `power`, `flow`, `valve_position`, etc.
+- `pressure`, `power` (0b46, delivered kW), `flow`, `valve_position`, etc.
+- `boiler_max_power_index` (0b62), `boiler_max_power_kw` (0b34, limit in kW; not written by this library—refresh after changing index)
 
 ## Async setters (write immediately)
 
 - `set_heater_mode(value)` — writes 0b55; if MANUAL also writes 0b32
 - `set_manual_temperature(value)` — writes 0b8d
+- `set_boiler_max_power_index(value)` — writes 0b62 only; firmware updates 0b34
 - `set_room_mode(value)`, `set_cwu_mode(value)`
 - `set_is_water_heater_enabled(value)`
 - `set_room_temperature_*`, `set_cwu_temperature_*`, etc.

--- a/src/kospel_cmi/controller/device.py
+++ b/src/kospel_cmi/controller/device.py
@@ -23,6 +23,7 @@ from ..registers.encoders import (
     encode_scaled_x10,
 )
 from ..registers.enums import (
+    BoilerMaxPowerIndex,
     CwuMode,
     HeaterMode,
     HeatingCircuitActive,
@@ -112,30 +113,22 @@ class Ekco_M3:
     @property
     def is_water_heater_enabled(self) -> Optional[WaterHeaterEnabled]:
         """Water heater enabled (bit 4 of 0b55)."""
-        return _decode_water_heater_enabled(
-            self._get_register("0b55"), 4
-        )
+        return _decode_water_heater_enabled(self._get_register("0b55"), 4)
 
     @property
     def is_co_heating_active(self) -> Optional[HeatingCircuitActive]:
         """CO heating circuit active (bit 7 of 0b51)."""
-        return _decode_co_heating_active(
-            self._get_register("0b51"), 7
-        )
+        return _decode_co_heating_active(self._get_register("0b51"), 7)
 
     @property
     def is_cwu_heating_active(self) -> Optional[HeatingCircuitActive]:
         """CWU heating circuit active (bit 8 of 0b51)."""
-        return _decode_cwu_heating_active(
-            self._get_register("0b51"), 8
-        )
+        return _decode_cwu_heating_active(self._get_register("0b51"), 8)
 
     @property
     def valve_position(self) -> Optional[ValvePosition]:
         """Valve position (bit 2 of 0b51)."""
-        return _decode_valve_position(
-            self._get_register("0b51"), 2
-        )
+        return _decode_valve_position(self._get_register("0b51"), 2)
 
     @property
     def manual_temperature(self) -> Optional[float]:
@@ -211,6 +204,22 @@ class Ekco_M3:
     def power(self) -> Optional[float]:
         """Current power (0b46), kW."""
         return decode_scaled_x10(self._get_register("0b46"))
+
+    @property
+    def boiler_max_power_index(self) -> Optional[BoilerMaxPowerIndex]:
+        """Max boiler power step index (0b62). Write via ``set_boiler_max_power_index``."""
+        raw = decode_raw_int(self._get_register("0b62"))
+        if raw is None:
+            return None
+        try:
+            return BoilerMaxPowerIndex(raw)
+        except ValueError:
+            return None
+
+    @property
+    def boiler_max_power_kw(self) -> Optional[float]:
+        """Configured max boiler power limit (0b34), kW (×10). Read-only; firmware updates after index write."""
+        return decode_scaled_x10(self._get_register("0b34"))
 
     @property
     def flow(self) -> Optional[float]:
@@ -346,6 +355,28 @@ class Ekco_M3:
             self._registers["0b30"] = hex_val
         return ok
 
+    async def set_boiler_max_power_index(
+        self, value: BoilerMaxPowerIndex | int
+    ) -> bool:
+        """Set max boiler power step (0b62)."""
+        idx = int(value)
+        try:
+            BoilerMaxPowerIndex(idx)
+        except ValueError as exc:
+            raise ValueError(
+                f"boiler_max_power_index must be 0..3 (BoilerMaxPowerIndex), got {idx}"
+            ) from exc
+
+        hex_val = encode_raw_int(idx, None)
+        if hex_val is None:
+            logger.error("Failed to encode boiler_max_power_index")
+            return False
+
+        ok = await self._backend.write_register("0b62", hex_val)
+        if ok:
+            self._registers["0b62"] = hex_val
+        return ok
+
     async def set_is_water_heater_enabled(self, value: WaterHeaterEnabled) -> bool:
         """Set water heater enabled (bit 4 of 0b55)."""
         current = self._get_register("0b55")
@@ -451,9 +482,7 @@ class Ekco_M3:
     async def set_water_mode(self, mode: CwuMode) -> bool:
         """Set CWU water mode (which temperature source is active)."""
         if not isinstance(mode, CwuMode):
-            raise TypeError(
-                f"mode must be CwuMode, got {type(mode).__name__}"
-            )
+            raise TypeError(f"mode must be CwuMode, got {type(mode).__name__}")
         return await self.set_cwu_mode(mode.value)
 
     async def set_water_comfort_temperature(self, temperature: float) -> bool:

--- a/src/kospel_cmi/registers/enums.py
+++ b/src/kospel_cmi/registers/enums.py
@@ -58,6 +58,22 @@ class CwuMode(IntEnum):
     COMFORT = 2  # Uses cwu_temperature_comfort (0b67)
 
 
+class BoilerMaxPowerIndex(IntEnum):
+    """Max boiler power selector.
+
+    Stored in register 0b62. Write this register to change the limit; register
+    0b34 reflects the selected limit in kW (×10) and is updated by firmware.
+
+    Member names match typical Ekco M3 steps; ordering may differ on other
+    models or firmware.
+    """
+
+    KW_2 = 0
+    KW_4 = 1
+    KW_6 = 2
+    KW_8 = 3
+
+
 # Firmware value for room_mode (0b32) when heater_mode=MANUAL.
 # Tells firmware to use manual_temperature (0b8d) as the target.
 ROOM_MODE_MANUAL = 64
@@ -71,4 +87,5 @@ ENUM_REGISTRY: dict[str, type[Enum]] = {
     "ValvePosition": ValvePosition,
     "HeatingStatus": HeatingStatus,
     "HeatingCircuitActive": HeatingCircuitActive,
+    "BoilerMaxPowerIndex": BoilerMaxPowerIndex,
 }

--- a/tests/unit/controller/test_device.py
+++ b/tests/unit/controller/test_device.py
@@ -3,7 +3,12 @@
 import pytest
 
 from kospel_cmi.controller.device import Ekco_M3
-from kospel_cmi.registers.enums import CwuMode, HeaterMode, HeatingStatus
+from kospel_cmi.registers.enums import (
+    BoilerMaxPowerIndex,
+    CwuMode,
+    HeaterMode,
+    HeatingStatus,
+)
 
 
 class MockRegisterBackend:
@@ -224,6 +229,66 @@ class TestEkco_M3:
         written_registers = {r for r, _ in backend.writes}
         assert written_registers == {"0b66"}
         assert backend.registers["0b66"] == "5e01"  # 35.0 in little-endian
+
+    @pytest.mark.asyncio
+    async def test_boiler_max_power_index_decodes_0b62(self) -> None:
+        """boiler_max_power_index reads 0b62 as BoilerMaxPowerIndex."""
+        backend = MockRegisterBackend({"0b62": "0200", "0b34": "3c00"})
+        controller = Ekco_M3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        assert controller.boiler_max_power_index == BoilerMaxPowerIndex.KW_6
+
+    @pytest.mark.asyncio
+    async def test_boiler_max_power_kw_decodes_0b34(self) -> None:
+        """boiler_max_power_kw reads 0b34 as kW (×10)."""
+        backend = MockRegisterBackend({"0b62": "0200", "0b34": "3c00"})
+        controller = Ekco_M3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        assert controller.boiler_max_power_kw == 6.0
+
+    @pytest.mark.asyncio
+    async def test_boiler_max_power_index_unknown_raw_returns_none(self) -> None:
+        """boiler_max_power_index is None when 0b62 is outside enum range."""
+        backend = MockRegisterBackend({"0b62": "0500"})
+        controller = Ekco_M3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        assert controller.boiler_max_power_index is None
+
+    @pytest.mark.asyncio
+    async def test_set_boiler_max_power_index_writes_0b62_only(self) -> None:
+        """set_boiler_max_power_index writes 0b62 and does not write 0b34."""
+        backend = MockRegisterBackend({"0b62": "0100", "0b34": "2800"})
+        controller = Ekco_M3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        success = await controller.set_boiler_max_power_index(BoilerMaxPowerIndex.KW_6)
+        assert success is True
+        written_registers = {r for r, _ in backend.writes}
+        assert written_registers == {"0b62"}
+        assert backend.registers["0b62"] == "0200"
+        assert backend.registers["0b34"] == "2800"
+        assert controller._registers["0b62"] == "0200"
+
+    @pytest.mark.asyncio
+    async def test_set_boiler_max_power_index_accepts_int(self) -> None:
+        """set_boiler_max_power_index accepts int in valid range."""
+        backend = MockRegisterBackend({"0b62": "0000"})
+        controller = Ekco_M3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        assert await controller.set_boiler_max_power_index(3) is True
+        assert backend.registers["0b62"] == "0300"
+
+    @pytest.mark.asyncio
+    async def test_set_boiler_max_power_index_raises_on_invalid_index(
+        self,
+    ) -> None:
+        """set_boiler_max_power_index raises ValueError for out-of-range index."""
+        backend = MockRegisterBackend({"0b62": "0100"})
+        controller = Ekco_M3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        with pytest.raises(ValueError, match="boiler_max_power_index"):
+            await controller.set_boiler_max_power_index(4)
+        with pytest.raises(ValueError, match="boiler_max_power_index"):
+            await controller.set_boiler_max_power_index(-1)
 
     @pytest.mark.asyncio
     async def test_co_heating_status_summer_disabled(self) -> None:


### PR DESCRIPTION
# Read/write max boiler power (Moc kotła)

## Summary

Adds support for the heater’s **maximum boiler power** limit on `Ekco_M3`: read/write the power **step index** on register **0b62** (aligned with the manufacturer UI’s `HU_POWER_INDEX`), and read the corresponding limit in **kW** from **0b34** (×10). The library **does not write 0b34**; firmware updates it after the index change.

Closes [JanKrl/kospel-cmi-lib#25](https://github.com/JanKrl/kospel-cmi-lib/issues/25).

## Motivation

Users want to cap how fast the boiler heats when it turns on (e.g. to match solar export). Live scans and the manufacturer config UI show that the **selector** is written as an integer index while **0b34** tracks the selected kW limit for display and logic.

## Changes

- **`BoilerMaxPowerIndex`** (`IntEnum` in `registers/enums.py`): steps **0–3** with names **KW_2**, **KW_4**, **KW_6**, **KW_8** for the typical Ekco M3 mapping observed on hardware (index order may differ on other variants—documented in the enum docstring). Registered in **`ENUM_REGISTRY`**.
- **`Ekco_M3`** (`controller/device.py`):
  - **`boiler_max_power_index`** → decode **0b62** to `Optional[BoilerMaxPowerIndex]`; out-of-range raw values return **`None`**.
  - **`boiler_max_power_kw`** → decode **0b34** as kW (scaled ×10).
  - **`set_boiler_max_power_index(value)`** → validates **0..3**, writes **0b62** only, updates the in-memory cache for **0b62** on success. Callers should **`refresh()`** to see an updated **0b34** after the device applies the change.
- **`controller/README.md`**: documents the new properties and setter, including the note that **0b34** is not written by the library.
- **Tests** (`tests/unit/controller/test_device.py`): decode behaviour, unknown index → `None`, write touches **0b62** only, **`ValueError`** for invalid indices, **`int`** accepted where valid.

## How to test

```bash
uv run python -m pytest tests/unit/controller/test_device.py -q
```

Full suite: `uv run python -m pytest -q`.

## Notes for reviewers

- **`power`** (register **0b46**) remains **current delivered power**; the new names avoid mixing it with the **configured max** limit.
- Writes use the existing **register HTTP backend** (`write_register`); no EKD `api/ekd/write` client in this PR.
