### PR TITLE
Fix error on empty register

### DIFF
--- a/src/kospel_cmi/kospel/api.py
+++ b/src/kospel_cmi/kospel/api.py
@@ -147,8 +147,17 @@ async def read_registers(
             raise KospelConnectionError(
                 f"Unexpected register key type in batch read: {type(reg_addr).__name__}"
             )
+        raw_value = str(raw)
+        if raw is None or raw_value.strip() == "":
+            logger.debug(
+                "Skipping register %s with unparsed batch value %r from %s",
+                reg_addr,
+                raw,
+                start_register,
+            )
+            continue
         try:
-            out[reg_addr] = validate_register_hex(str(raw))
+            out[reg_addr] = validate_register_hex(raw_value)
         except RegisterValueInvalidError as e:
             raise RegisterValueInvalidError(
                 f"Invalid hex for register {reg_addr} in batch read"

--- a/tests/unit/kospel/test_api.py
+++ b/tests/unit/kospel/test_api.py
@@ -88,6 +88,19 @@ async def test_read_registers_invalid_entry_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_read_registers_skips_empty_values() -> None:
+    """read_registers skips empty string values and returns only valid entries."""
+    with aioresponses.aioresponses() as m:
+        m.get(
+            f"{BASE}/0b00/4",
+            payload={"regs": {"0b00": "0100", "0b8e": ""}},
+        )
+        async with aiohttp.ClientSession() as session:
+            regs = await read_registers(session, BASE, "0b00", 4)
+            assert regs == {"0b00": "0100"}
+
+
+@pytest.mark.asyncio
 async def test_write_register_success_returns_none() -> None:
     """write_register completes without error on status 0."""
     with aioresponses.aioresponses() as m:


### PR DESCRIPTION
# PR: Handle empty batch register values gracefully

## Summary

This PR fixes a failure mode in `src/kospel_cmi/kospel/api.py` where the batch register reader failed when the heater returned a register value as an empty string.

## What changed

- Updated `read_registers()` in `src/kospel_cmi/kospel/api.py` to skip batch entries with `null` or empty string payloads.
- Added a regression test in `tests/unit/kospel/test_api.py` to verify that empty-string register values are ignored and do not break the batch read.
- Improved debug logging to include the unparsed raw value for skipped registers.

## Why

Some heater responses include optional registers with blank values instead of valid 4-character hex strings. The previous implementation raised `RegisterValueInvalidError` and caused Home Assistant updates to fail.

## Test coverage

- `uv run python -m pytest -q tests/unit/kospel/test_api.py`
- Result: `9 passed`
