### PR TITLE
Add outside temperature swtich setting

### DIFF
--- a/src/kospel_cmi/controller/device.py
+++ b/src/kospel_cmi/controller/device.py
@@ -86,6 +86,7 @@ _EKCOM3_READ_REGISTERS: frozenset[str] = frozenset(
         "0b6e",
         "0b6f",
         "0b70",
+        "0b74",
         "0b8a",
         "0b8d",
     }
@@ -270,6 +271,11 @@ class EkcoM3:
     def outside_temperature(self) -> Optional[float]:
         """Outside temperature (0b4c), °C."""
         return decode_scaled_x10(self._get_register("0b4c"))
+
+    @property
+    def outside_temperature_off(self) -> Optional[float]:
+        """Outside temperature off threshold (0b74), °C."""
+        return decode_scaled_x10(self._get_register("0b74"))
 
     @property
     def supply_setpoint(self) -> Optional[float]:
@@ -464,6 +470,10 @@ class EkcoM3:
 
         await self._backend.write_register("0b8d", hex_val)
         self._registers["0b8d"] = hex_val
+
+    async def set_outside_temperature_off(self, value: float) -> None:
+        """Set outside temperature off threshold (0b74), °C."""
+        await self._set_scaled_x10("0b74", value)
 
     async def set_room_temperature_economy(self, value: float) -> None:
         """Set room temperature economy (0b68), °C."""

--- a/src/kospel_cmi/registers/README.md
+++ b/src/kospel_cmi/registers/README.md
@@ -74,6 +74,7 @@ Register values may vary per device type / version. Currently the project includ
 - `0b2f`: Water temperature setting
 - `0b4a`: Water current temperature
 - `0b4c`: Outside temperature
+- `0b74`: Outside temperature off threshold
 - `0b48`: Inlet temperature
 - `0b49`: Outlet temperature
 - `0b44`: Factor

--- a/tests/unit/controller/test_device.py
+++ b/tests/unit/controller/test_device.py
@@ -215,6 +215,25 @@ class TestEkcoM3:
         assert "0b32" not in written_registers
 
     @pytest.mark.asyncio
+    async def test_outside_temperature_off_property_decodes_0b74(self) -> None:
+        """outside_temperature_off reads 0b74 as °C."""
+        backend = MockRegisterBackend({"0b74": "c800"})
+        controller = EkcoM3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        assert controller.outside_temperature_off == 20.0
+
+    @pytest.mark.asyncio
+    async def test_set_outside_temperature_off_writes_0b74_only(self) -> None:
+        """set_outside_temperature_off writes only 0b74."""
+        backend = MockRegisterBackend({"0b74": "0000", "0b32": "0100"})
+        controller = EkcoM3(backend=backend)
+        controller.from_registers(await backend.read_registers("0b00", 256))
+        await controller.set_outside_temperature_off(20.0)
+        written_registers = {r for r, _ in backend.writes}
+        assert written_registers == {"0b74"}
+        assert backend.registers["0b74"] == "c800"
+
+    @pytest.mark.asyncio
     async def test_set_manual_heating_writes_mode_and_temp_registers(
         self,
     ) -> None:


### PR DESCRIPTION
# Summary
This PR adds handling of a new register 0b74 which is responsible for setting a threshold on outside temperature sensor value which switches off the heating.

# What changed
Added a new read/write register for EkcoM3 device.