### PR TITLE
feat: Dynamic boiler max power settings discovery

### DIFF
--- a/docs/register_mapping_from_ui.md
+++ b/docs/register_mapping_from_ui.md
@@ -192,10 +192,10 @@ Interfejs odświeża ekran startowy odczytem 30 rejestrów od 0b2f. Poniżej map
 
 | Rejestr | Znaczenie |
 |---------|-----------|
-| 0b25 | Indeks (7 rejestrów) |
-| 0b34 | Moc kotła | ×10 kW |
-| 0b35 | Indeks (6 rejestrów) |
-| 0b62 | Moc kotła (konfiguracja) |
+| 0b25 | Ilość dostępnych opcji wysokości podnoszenia pompy | Kolejne rejestry (od `0b26`) zawierają wartości dla każdego indeksu (0, 1, 2...) |
+| 0b34 | Aktualna moc kotła | ×10 kW |
+| 0b35 | Ilość dostępnych opcji maksymalnej mocy kotła | Kolejne rejestry (od `0b36`) zawierają wartości (w ×10 kW) dla każdego indeksu (0, 1, 2...). Liczba opcji zależy od sprzętu. |
+| 0b62 | Wybrany indeks maksymalnej mocy kotła | Zapisywany jako indeks (0, 1, 2...) wybranej z listy opcji zdefiniowanej w `0b35`. Nie wpisujemy tu wartości kW! |
 | 0b7f | Tryb pracy: 0=podstawowy, 1=źródło ciepła, 2=bufor |
 | 0b8a | Tryb pracy: 0=CO, 1=źródło ciepła, 2=bufor |
 | 0be5 | Tryb pracy min (zakres) |

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -193,7 +193,7 @@ Heater mode (bits 3, 5, 6, 7, 9): OFF, SUMMER, WINTER, PARTY, VACATION, MANUAL â
 - **Setters**: Raise on write failure (same types as the backend) instead of returning `False`.
 
 **Application-level validation**:
-- Invalid enum/range arguments may raise `ValueError` or `TypeError` with a clear message (e.g. invalid `BoilerMaxPowerIndex`).
+- Invalid enum/range arguments may raise `ValueError` or `TypeError` with a clear message (e.g. max power index out of dynamically queried bounds).
 
 ## Implementation Details
 
@@ -265,6 +265,12 @@ Decoder(Protocol[T]): ...
 - Group writes by register address
 - Read-modify-write pattern for registers with multiple settings
 - Only write if value actually changed
+
+### Dynamic Hardware Capabilities
+
+Certain settings on Kospel devices, such as the maximum power limit and the pump lift options, depend entirely on the specific physical hardware unit connected.
+- **Max Power Limit:** Instead of a static enum of options, the device reports the length of available power settings in register `0b35` and uses subsequent registers (`0b36`, `0b37`, etc.) to provide the specific kW value options. The currently selected index is stored in `0b62`.
+- **Stateless Integration:** Because these hardware capabilities never change during runtime, and because `refresh()` fetches 256 registers starting at `0b00` (which inherently captures these arrays), the library derives these lists dynamically on the fly from the cached register snapshot rather than performing any custom initialization queries or maintaining separate metadata state.
 
 ### YAML / simulator (function module)
 

--- a/src/kospel_cmi/controller/device.py
+++ b/src/kospel_cmi/controller/device.py
@@ -28,7 +28,6 @@ from ..registers.encoders import (
 )
 from ..registers.enums import (
     ROOM_MODE_MANUAL,
-    BoilerMaxPowerIndex,
     CwuMode,
     HeaterMode,
     HeatingCircuitActive,
@@ -36,6 +35,8 @@ from ..registers.enums import (
     ValvePosition,
     WaterHeaterEnabled,
 )
+from ..registers.utils import int_to_reg_address
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,6 @@ _encode_water_heater_enabled = encode_map(
     WaterHeaterEnabled.ENABLED, WaterHeaterEnabled.DISABLED
 )
 
-# All registers used by public read-only properties on EkcoM3 (strict refresh).
 _EKCOM3_READ_REGISTERS: frozenset[str] = frozenset(
     {
         "0b2f",
@@ -63,6 +63,7 @@ _EKCOM3_READ_REGISTERS: frozenset[str] = frozenset(
         "0b31",
         "0b32",
         "0b34",
+        "0b35",
         "0b46",
         "0b48",
         "0b49",
@@ -293,15 +294,32 @@ class EkcoM3:
         return decode_scaled_x10(self._get_register("0b46"))
 
     @property
-    def boiler_max_power_index(self) -> Optional[BoilerMaxPowerIndex]:
+    def boiler_max_power_index(self) -> Optional[int]:
         """Max boiler power step index (0b62). Use ``set_boiler_max_power_index``."""
-        raw = decode_raw_int(self._get_register("0b62"))
-        if raw is None:
-            return None
+        return decode_raw_int(self._get_register("0b62"))
+
+    @property
+    def available_boiler_max_power_settings(self) -> list[float]:
+        """Available max power settings (kW) dynamically queried from the heater."""
         try:
-            return BoilerMaxPowerIndex(raw)
-        except ValueError:
-            return None
+            count = decode_raw_int(self._get_register("0b35"))
+        except RegisterMissingError:
+            return []
+        
+        if not count:
+            return []
+            
+        options = []
+        for i in range(count):
+            reg_addr = int_to_reg_address("0b", 0x36 + i)
+            try:
+                val = decode_scaled_x10(self._get_register(reg_addr))
+                if val is not None:
+                    options.append(val)
+            except RegisterMissingError:
+                continue
+                
+        return options
 
     @property
     def boiler_max_power_kw(self) -> Optional[float]:
@@ -433,16 +451,16 @@ class EkcoM3:
         self._registers["0b30"] = hex_val
 
     async def set_boiler_max_power_index(
-        self, value: BoilerMaxPowerIndex | int
+        self, value: int
     ) -> None:
-        """Set max boiler power step (0b62)."""
+        """Set max boiler power step index (0b62)."""
         idx = int(value)
-        try:
-            BoilerMaxPowerIndex(idx)
-        except ValueError as exc:
+        
+        available = self.available_boiler_max_power_settings
+        if available and not (0 <= idx < len(available)):
             raise ValueError(
-                f"boiler_max_power_index must be 0..3 (BoilerMaxPowerIndex), got {idx}"
-            ) from exc
+                f"boiler_max_power_index {idx} is out of bounds for available settings {available}"
+            )
 
         hex_val = encode_raw_int(idx, None)
         if hex_val is None:

--- a/src/kospel_cmi/registers/enums.py
+++ b/src/kospel_cmi/registers/enums.py
@@ -58,21 +58,6 @@ class CwuMode(IntEnum):
     COMFORT = 2  # Uses cwu_temperature_comfort (0b67)
 
 
-class BoilerMaxPowerIndex(IntEnum):
-    """Max boiler power selector.
-
-    Stored in register 0b62. Write this register to change the limit; register
-    0b34 reflects the selected limit in kW (×10) and is updated by firmware.
-
-    Member names match typical Ekco M3 steps; ordering may differ on other
-    models or firmware.
-    """
-
-    KW_2 = 0
-    KW_4 = 1
-    KW_6 = 2
-    KW_8 = 3
-
 
 # Firmware value for room_mode (0b32) when heater_mode=MANUAL.
 # Tells firmware to use manual_temperature (0b8d) as the target.
@@ -87,5 +72,4 @@ ENUM_REGISTRY: dict[str, type[Enum]] = {
     "ValvePosition": ValvePosition,
     "HeatingStatus": HeatingStatus,
     "HeatingCircuitActive": HeatingCircuitActive,
-    "BoilerMaxPowerIndex": BoilerMaxPowerIndex,
 }

--- a/tests/unit/controller/test_device.py
+++ b/tests/unit/controller/test_device.py
@@ -295,11 +295,12 @@ class TestEkcoM3:
         assert written_registers == {"0b66"}
         assert backend.registers["0b66"] == "5e01"  # 35.0 in little-endian
 
-    def test_boiler_max_power_index_decodes_0b62(self) -> None:
+    @pytest.mark.asyncio
+    async def test_boiler_max_power_index_decodes_0b62(self) -> None:
         """boiler_max_power_index reads 0b62 as int."""
         backend = MockRegisterBackend({"0b62": "0200", "0b34": "3c00"})
         controller = EkcoM3(backend=backend)
-        controller.from_registers({"0b62": "0200", "0b34": "3c00"})
+        controller.from_registers(await backend.read_registers("0b00", 256))
         assert controller.boiler_max_power_index == 2
 
     @pytest.mark.asyncio
@@ -310,11 +311,12 @@ class TestEkcoM3:
         controller.from_registers(await backend.read_registers("0b00", 256))
         assert controller.boiler_max_power_kw == 6.0
 
-    def test_available_boiler_max_power_settings(self) -> None:
+    @pytest.mark.asyncio
+    async def test_available_boiler_max_power_settings(self) -> None:
         """available_boiler_max_power_settings dynamically queries 0b35 onwards."""
         backend = MockRegisterBackend({"0b35": "0300", "0b36": "2800", "0b37": "3c00", "0b38": "5000"})
         controller = EkcoM3(backend=backend)
-        controller.from_registers({"0b35": "0300", "0b36": "2800", "0b37": "3c00", "0b38": "5000"})
+        controller.from_registers(await backend.read_registers("0b00", 256))
         assert controller.available_boiler_max_power_settings == [4.0, 6.0, 8.0]
 
     @pytest.mark.asyncio

--- a/tests/unit/controller/test_device.py
+++ b/tests/unit/controller/test_device.py
@@ -295,7 +295,6 @@ class TestEkcoM3:
         assert written_registers == {"0b66"}
         assert backend.registers["0b66"] == "5e01"  # 35.0 in little-endian
 
-    @pytest.mark.asyncio
     def test_boiler_max_power_index_decodes_0b62(self) -> None:
         """boiler_max_power_index reads 0b62 as int."""
         backend = MockRegisterBackend({"0b62": "0200", "0b34": "3c00"})
@@ -311,7 +310,6 @@ class TestEkcoM3:
         controller.from_registers(await backend.read_registers("0b00", 256))
         assert controller.boiler_max_power_kw == 6.0
 
-    @pytest.mark.asyncio
     def test_available_boiler_max_power_settings(self) -> None:
         """available_boiler_max_power_settings dynamically queries 0b35 onwards."""
         backend = MockRegisterBackend({"0b35": "0300", "0b36": "2800", "0b37": "3c00", "0b38": "5000"})
@@ -339,9 +337,9 @@ class TestEkcoM3:
     ) -> None:
         """set_boiler_max_power_index raises ValueError for out-of-range index."""
         # Only 2 items available (0..1)
-        backend = MockRegisterBackend({"0b35": "0200", "0b62": "0100"})
+        backend = MockRegisterBackend({"0b35": "0200", "0b36": "2800", "0b37": "3c00", "0b62": "0100"})
         controller = EkcoM3(backend=backend)
-        controller.from_registers({"0b35": "0200", "0b62": "0100"})
+        controller.from_registers({"0b35": "0200", "0b36": "2800", "0b37": "3c00", "0b62": "0100"})
         with pytest.raises(ValueError, match="boiler_max_power_index"):
             await controller.set_boiler_max_power_index(2)
         with pytest.raises(ValueError, match="boiler_max_power_index"):

--- a/tests/unit/controller/test_device.py
+++ b/tests/unit/controller/test_device.py
@@ -9,7 +9,6 @@ from kospel_cmi.exceptions import (
     RegisterMissingError,
 )
 from kospel_cmi.registers.enums import (
-    BoilerMaxPowerIndex,
     CwuMode,
     HeaterMode,
     HeatingStatus,
@@ -297,12 +296,12 @@ class TestEkcoM3:
         assert backend.registers["0b66"] == "5e01"  # 35.0 in little-endian
 
     @pytest.mark.asyncio
-    async def test_boiler_max_power_index_decodes_0b62(self) -> None:
-        """boiler_max_power_index reads 0b62 as BoilerMaxPowerIndex."""
+    def test_boiler_max_power_index_decodes_0b62(self) -> None:
+        """boiler_max_power_index reads 0b62 as int."""
         backend = MockRegisterBackend({"0b62": "0200", "0b34": "3c00"})
         controller = EkcoM3(backend=backend)
-        controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.boiler_max_power_index == BoilerMaxPowerIndex.KW_6
+        controller.from_registers({"0b62": "0200", "0b34": "3c00"})
+        assert controller.boiler_max_power_index == 2
 
     @pytest.mark.asyncio
     async def test_boiler_max_power_kw_decodes_0b34(self) -> None:
@@ -313,20 +312,21 @@ class TestEkcoM3:
         assert controller.boiler_max_power_kw == 6.0
 
     @pytest.mark.asyncio
-    async def test_boiler_max_power_index_unknown_raw_returns_none(self) -> None:
-        """boiler_max_power_index is None when 0b62 is outside enum range."""
-        backend = MockRegisterBackend({"0b62": "0500"})
+    def test_available_boiler_max_power_settings(self) -> None:
+        """available_boiler_max_power_settings dynamically queries 0b35 onwards."""
+        backend = MockRegisterBackend({"0b35": "0300", "0b36": "2800", "0b37": "3c00", "0b38": "5000"})
         controller = EkcoM3(backend=backend)
-        controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.boiler_max_power_index is None
+        controller.from_registers({"0b35": "0300", "0b36": "2800", "0b37": "3c00", "0b38": "5000"})
+        assert controller.available_boiler_max_power_settings == [4.0, 6.0, 8.0]
 
     @pytest.mark.asyncio
     async def test_set_boiler_max_power_index_writes_0b62_only(self) -> None:
         """set_boiler_max_power_index writes 0b62 and does not write 0b34."""
-        backend = MockRegisterBackend({"0b62": "0100", "0b34": "2800"})
+        # 0b35: 4 items (0400), we select index 2
+        backend = MockRegisterBackend({"0b35": "0400", "0b62": "0100", "0b34": "2800"})
         controller = EkcoM3(backend=backend)
-        controller.from_registers(await backend.read_registers("0b00", 256))
-        await controller.set_boiler_max_power_index(BoilerMaxPowerIndex.KW_6)
+        controller.from_registers({"0b35": "0400", "0b62": "0100", "0b34": "2800"})
+        await controller.set_boiler_max_power_index(2)
         written_registers = {r for r, _ in backend.writes}
         assert written_registers == {"0b62"}
         assert backend.registers["0b62"] == "0200"
@@ -334,24 +334,16 @@ class TestEkcoM3:
         assert controller._registers["0b62"] == "0200"
 
     @pytest.mark.asyncio
-    async def test_set_boiler_max_power_index_accepts_int(self) -> None:
-        """set_boiler_max_power_index accepts int in valid range."""
-        backend = MockRegisterBackend({"0b62": "0000"})
-        controller = EkcoM3(backend=backend)
-        controller.from_registers(await backend.read_registers("0b00", 256))
-        await controller.set_boiler_max_power_index(3)
-        assert backend.registers["0b62"] == "0300"
-
-    @pytest.mark.asyncio
     async def test_set_boiler_max_power_index_raises_on_invalid_index(
         self,
     ) -> None:
         """set_boiler_max_power_index raises ValueError for out-of-range index."""
-        backend = MockRegisterBackend({"0b62": "0100"})
+        # Only 2 items available (0..1)
+        backend = MockRegisterBackend({"0b35": "0200", "0b62": "0100"})
         controller = EkcoM3(backend=backend)
-        controller.from_registers(await backend.read_registers("0b00", 256))
+        controller.from_registers({"0b35": "0200", "0b62": "0100"})
         with pytest.raises(ValueError, match="boiler_max_power_index"):
-            await controller.set_boiler_max_power_index(4)
+            await controller.set_boiler_max_power_index(2)
         with pytest.raises(ValueError, match="boiler_max_power_index"):
             await controller.set_boiler_max_power_index(-1)
 


### PR DESCRIPTION
## Description

Replaces the static enum `BoilerMaxPowerIndex` with a dynamic property that queries the boiler for available power limit settings based on the connected hardware unit's capabilities.

## Motivation

The Home Assistant integration requires discovering hardware-specific available settings (such as available kW power options) that vary between different models of Kospel boilers. The previous hardcoded enum did not reflect real hardware accurately.

## Changes

- Removed `BoilerMaxPowerIndex` enum entirely
- Added `available_boiler_max_power_settings` dynamic property to `EkcoM3` that utilizes `0b35` and `0b36+`
- Added out-of-bounds safety validation in `set_boiler_max_power_index`
- Updated unit tests with dynamic mocked payloads 
- Updated documentation in `register_mapping_from_ui.md` and `technical.md`

## Testing

- [x] All existing tests pass (`uv run pytest`)
- [x] New tests added (if applicable)
- [x] Code coverage maintained (≥80%)

## Checklist

- [x] Code follows project conventions (see [CLAUDE.md](CLAUDE.md))
- [x] Type hints added for new/modified public methods
- [x] `docs/` updated (if new architecture/developer changes)
